### PR TITLE
[WIP] feat(card): add card component

### DIFF
--- a/src/commons/Card/index.jsx
+++ b/src/commons/Card/index.jsx
@@ -1,0 +1,29 @@
+/* @flow */
+import React from 'react';
+// TODO replace this import
+import Card from '@windingtree/wt-ui-react/lib/components/Card';
+
+type PropType = {
+    imgSrc: string,
+    title: string,
+    linkText: string,
+    href: string
+};
+
+const WTCard = (props: PropType) => {
+  const {
+    imgSrc, title, linkText, href,
+  } = props;
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Image src={imgSrc} variant="top" />
+      </Card.Header>
+      <Card.Body>
+        <Card.Title>{title}</Card.Title>
+        <Card.Link href={href}>{linkText}</Card.Link>
+      </Card.Body>
+    </Card>
+  );
+};
+export default WTCard;


### PR DESCRIPTION
Added common card component using `Card` component from wt-react-ui.
This PR it's blocked by [wt-react-ui#64](https://github.com/windingtree/wt-ui-react/pull/64). After generating a new version of react-ui, I could update this pr and will be ready to merge.
